### PR TITLE
set stats to start automatically, resolves #4

### DIFF
--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -11,7 +11,6 @@ var Batch = require('./Batch'),
 // var debug = function(){};
 
 var stats = require('./stats');
-stats.start();
 
 function BatchManager( opts ){
 
@@ -105,7 +104,11 @@ BatchManager.prototype.flush = function(){
 // call this on stream end
 BatchManager.prototype.end = function(){
   this.finished = true;
-  this.flush();
+  if( this._current._slots.length ){
+    this.flush();
+  } else {
+    this._attemptEnd();
+  }
 };
 
 BatchManager.prototype._attemptEnd = function(){

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,6 +1,7 @@
 
 function Stats(){
   this.data = { start: new Date().getTime() };
+  this.active = false;
   this.watching = {};
 }
 
@@ -37,13 +38,22 @@ Stats.prototype.runWatchers = function(){
 };
 
 Stats.prototype.end = function(){
-  this.updateStats();
-  clearInterval( this.interval );
-  this.data.end = new Date().getTime();
-  this.flush();
+  if( this.active ){  
+    this.updateStats();
+    clearInterval( this.interval );
+    this.data.end = new Date().getTime();
+    this.flush();
+  }
 };
 
 Stats.prototype.inc = function( key, num ){
+
+  // start logging stats after the first update
+  if( !this.active ){
+    this.active = true;
+    this.start();
+  }
+
   if( !this.data.hasOwnProperty(key) ){
     this.data[key] = 0;
   }


### PR DESCRIPTION
this prevents the stats from starting on their own, which is really annoying, especially when using the dbclient for read-only.
