### PR TITLE
make elasticsearch client a singleton

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,10 +2,14 @@
 var elasticsearch = require('elasticsearch'),
     settings = require('pelias-config').generate();
 
+var singleton = null;
+
 module.exports = function(){
 
   // Create new esclient with settings
-  var client = new elasticsearch.Client( settings.export().esclient || {} );
-  
-  return client;
+  if( !singleton ){
+    singleton = new elasticsearch.Client( settings.export().esclient || {} );
+  }
+
+  return singleton;
 };


### PR DESCRIPTION
make elasticsearch client a singleton, to avoid creating multiple clients which all need to be manually closed before the process exits
