### PR TITLE
Fix the longstanding annoying persec bug

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -1,10 +1,11 @@
 var winston = require( 'pelias-logger' ).get( 'dbclient' );
-var peliasConfig = require( 'pelias-config' );
+var peliasConfig = require( 'pelias-config' ).generate().dbclient;
 
 function Stats(){
   this.data = {};
   this.active = false;
   this.watching = {};
+  this.lastIndexCount = 0;
 }
 
 Stats.prototype.watch = function( key, func ){
@@ -13,16 +14,15 @@ Stats.prototype.watch = function( key, func ){
 
 Stats.prototype.start = function(){
   this.end();
-  var interval = peliasConfig.generate().dbclient.statFrequency;
+  var interval = peliasConfig.statFrequency;
   this.interval = setInterval( this.updateStats.bind(this), interval );
 };
 
 Stats.prototype.updateStats = function(){
   if( this.data.indexed ){
-    if( this.lastIndexCount ){
-      var indexPerSec = this.data.indexed - this.lastIndexCount;
-      this.data.persec = indexPerSec;
-    }
+    var seconds = peliasConfig.statFrequency / 1000;
+    var change = this.data.indexed - this.lastIndexCount;
+    this.data.persec = change / seconds;
     this.lastIndexCount = this.data.indexed;
   }
 


### PR DESCRIPTION
For as long as I can remember, the dbclient has output statistics about an ongoing import, including the import rate in records/second. The only problem was that the import rate was wrong.

It turns out the code didn't take into account the time between prints, and assumed it was 1 second. It's actually configurable and defaults to 10 seconds, so the displayed rates defaulted to 10x too high. 

It's fixed now :watch: