### PR TITLE
Elasticsearch client, which supports document updating/merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ $ npm test
 
 ### Continuous Integration
 
-Travis tests every release against node version `0.10`
+Travis tests every release against node versions `0.10`, `0.12`, `4.x` and `5.x`
 
 [![Build Status](https://travis-ci.org/pelias/dbclient.png?branch=master)](https://travis-ci.org/pelias/dbclient)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var client = peliasDbclient({
     mergeFields: ['name'],     // optional list of fields that need merging (default = whole doc)
     mergeAssignFrom: ['name'], // to keep the phrase field valid when name changes.
     mergeAssignTo: ['phrase']  // target field for each 'From' array entry above.
-    		   	       // mergeAssignFrom.length must match mergeAssignTo.length
+                               // mergeAssignFrom.length must match mergeAssignTo.length
   });
   // Index as usual. Whenever document ids match, the new data updates the old doc.
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelias-dbclient",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Database client for Pelias import pipelines",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We currently use the new merge mode to combine OpenAddresses documents, which define a same address in two different languages. Merging combines name.fi and name.sv. 