### PR TITLE
Log import progress at info level instead of verbose

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -31,7 +31,7 @@ Stats.prototype.updateStats = function(){
 };
 
 Stats.prototype.flush = function(){
-  winston.verbose( this.data );
+  winston.info( this.data );
 };
 
 Stats.prototype.runWatchers = function(){


### PR DESCRIPTION
Every 10 seconds (by default), the dbclient prints out info during data
imports like the speed of the import, how many records have been
imported, as well as info on each type of record imported. These are
useful not just to show progress but to reassure people that progress is
being made in the import (which can take hours).

Recently a few people have asked about progress output and as it turns
out, we were not, by default, showing this output. The fix was to
default to [debug](https://github.com/pelias/config/pull/29) logging, which is quite high for a default.

After more thought, it feels like the [verbose level](https://github.com/winstonjs/winston#logging-levels)
is too high for this progress info that really should generally be
output, so this commit moves it to the info level.

This would allow us to revert the debug change to pelias-config, and
then other verbose output like the OSM importer point data and the
wof-admin-lookup suspect record log could go into verbose or debug as
appropriate, and not be shown by default.