### PR TITLE
Wait elasticsearch job done to call `flush` callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,68 @@
-
 ## Install Dependencies
 
 ```bash
 $ npm install
+```
+
+## Usage
+This module returns “streamFactory” —a function that produces a transforming stream. The stream puts documents into elasticsearch during import pipeline. Note: this stream triggers finish event only after all documents are stored into elasticsearch.
+
+
+```javascript
+'use strict';
+
+// some_importer.js
+
+const streamify = require('stream-array');
+const through = require('through2');
+const Document = require('pelias-model').Document;
+const dbMapper = require('pelias-model').createDocumentMapperStream;
+const dbclient = require('pelias-dbclient');
+
+const elasticsearch = require('elasticsearch');
+const config = require('pelias-config').generate();
+const elasticDeleteQuery = require('elastic-deletebyquery');
+
+const timestamp = Date.now();
+
+const stream = streamify([1, 2, 3])
+  .pipe(through.obj((item, enc, next) => {
+    const uniqueId = [ 'docType', item ].join(':'); // documents with the same id will be updated
+    const doc = new Document( 'sourceType', 'venue', uniqueId );
+    doc.timestamp = timestamp;
+    next(null, doc);
+  }))
+  .pipe(dbMapper())
+  .pipe(dbclient()); // put documents into elasticsearch
+    
+stream.on('finish', () => {
+  // let's assume that documents with the same type but another timestamp (for example old copies)
+  // have to be deleted
+  const client = new elasticsearch.Client(config.esclient);
+  elasticDeleteQuery(client);
+    
+  const options = {
+    index: config.schema.indexName,
+    type: 'venue',
+    body: {
+      query: {
+        "bool": {
+          "must": [
+            {"term": { "source":  "sourceType" }}
+          ],
+          "must_not": [
+            {"term": { "timestamp":  timestamp }}
+          ]
+        }
+      }
+    }
+  };
+  
+  client.deleteByQuery(options, (err, response) => {
+    console.log('The elements deleted are: %s', response.elements);
+  });
+});
+
 ```
 
 ## Contributing

--- a/src/sink.js
+++ b/src/sink.js
@@ -10,8 +10,8 @@ function streamFactory( opts ){
 
   var stream = through.obj( function( item, enc, next ){
     manager.push( item, next );
-  }, function(){
-    manager.end();
+  }, function(next) {
+    manager.end(next);
   });
 
   // export client

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const proxyquire = require('proxyquire').noCallThru();
 
 module.exports.tests = {};

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,40 +1,58 @@
+'use strict';
+
+const proxyquire = require('proxyquire').noCallThru();
+const through = require('through2');
+
 module.exports.tests = {};
 
-// module.exports.tests.functional_example = function(test, common) {
-//  var factory = require('../index');
+module.exports.tests.functional_example = function(test, common) {
+  const factory = proxyquire('../index', {
+    './src/configValidation': {
+      validate: () => {}
+    }
+  });
 
-//   test('functional example', function(t) {
+  test('functional example', function(t) {
 
-//     t.plan(2);
+    let finished = false;
 
-//     var assertStream = through.obj( function( chunk, enc, next ){
-//       t.equal( chunk.test, 'test1', 'transform stream' );
-//       next();
-//     });
+    t.plan(2);
 
-//     var client = {
-//       bulk: function( batch, cb ){
-//         setInterval( function(){
-//           return cb( 'expected failure' );
-//         }, 500 );
-//       },
-//       close: function(){
-//         t.equal( true, true, 'client closed' );
-//       }
-//     };
+    var assertStream = through.obj( function( chunk, enc, next ) {
+      t.fail('should not be called since we don\'t provide any output');
+      next();
+    });
 
-//     var stream = factory({ client: client });
-//     stream.pipe(assertStream);
-//     stream.write({
-//       _index: 'foo',
-//       _type: 'foo',
-//       _id: 'foo',
-//       data: {}
-//     });
-//     stream.end();
+    assertStream.on('finish', () => {
+      t.equal(finished, true, 'assertStream finishes after bulk operation');
+    });
 
-//   });
-// };
+    var client = {
+      bulk: function( batch, cb ){
+        setTimeout( function(){
+          finished = true;
+          cb(null);
+        }, 500 );
+      },
+      close: function(){
+        t.equal( true, true, 'client closed' );
+      }
+    };
+
+    var stream = factory({ client: client });
+
+    stream.pipe(assertStream);
+    stream.write({
+      _index: 'foo',
+      _type: 'foo',
+      _id: 'foo',
+      data: {}
+    });
+
+    stream.end();
+
+  });
+};
 
 module.exports.all = function (tape, common) {
 


### PR DESCRIPTION
In some usecases it's very important to know when exactly elasticsearch stream finishes. In order to achieve this we could receive callback to `flush function` and call it `after` elasticsearch job will finish. 
#49 