### PR TITLE
Skip validation in test env

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
-require('./src/configValidation').validate(require('pelias-config').generate());
+if (process.env.NODE_ENV !== 'test') {
+  require('./src/configValidation').validate(require('pelias-config').generate());
+}
 
 module.exports = require('./src/sink');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "node test/run.js | tap-spec",
+    "test": "NODE_ENV=test node test/run.js | tap-spec",
     "lint": "jshint .",
     "validate": "npm ls",
     "check-dependencies": "node_modules/.bin/npm-check --production",

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,10 @@ module.exports.tests.interface = function(test) {
 
 module.exports.tests.invalidConfig = function(test) {
   test('configValidation throwing error should rethrow', function(t) {
+    const env = process.env.NODE_ENV;
+    // validation is skipping by default in test environment
+    process.env.NODE_ENV = 'development';
+
     t.throws(function() {
       proxyquire('../index', {
         './src/configValidation': {
@@ -46,6 +50,8 @@ module.exports.tests.invalidConfig = function(test) {
       });
 
     }, /config is not valid/);
+
+    process.env.NODE_ENV = env;
 
     t.end();
 


### PR DESCRIPTION
Possible fix for #48 
Required `NODE_ENV=test` for skipping config validation during test launching.