### PR TITLE
fix: Use correct callback signature for indices.exists

### DIFF
--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -29,7 +29,7 @@ module.exports = {
       const esclient = new elasticsearch.Client(config.esclient);
 
       // callback that throws an error if the index doesn't exist
-      const existsCallback = (exists) => {
+      const existsCallback = (error, exists) => {
         if (!exists) {
           console.error(`ERROR: Elasticsearch index ${config.schema.indexName} does not exist`);
           console.error('You must use the pelias-schema tool (https://github.com/pelias/schema/) to create the index first');

--- a/test/configValidation.js
+++ b/test/configValidation.js
@@ -239,7 +239,7 @@ module.exports.tests.validate = function(test, common) {
       proxyquire('../src/configValidation', {
         'elasticsearch': {
           Client: function() {
-            return { indices: { exists: (indexName, cb) => { cb(true); } } };
+            return { indices: { exists: (indexName, cb) => { cb(false, true); } } };
           }
         }
       }).validate(config);
@@ -266,7 +266,7 @@ module.exports.tests.validate = function(test, common) {
       proxyquire('../src/configValidation', {
         'elasticsearch': {
           Client: function() {
-            return { indices: { exists: (indexName, cb) => { cb(true); } } };
+            return { indices: { exists: (indexName, cb) => { cb(false, true); } } };
           }
         }
       }).validate(config);
@@ -302,7 +302,7 @@ module.exports.tests.validate = function(test, common) {
       proxyquire('../src/configValidation', {
         'elasticsearch': {
           Client: function() {
-            return { indices: { exists: (indexName, cb) => { cb(false); } } };
+            return { indices: { exists: (indexName, cb) => { cb(false, false); } } };
           }
         }
       }).validate(config);


### PR DESCRIPTION
It turns out all elasticsearch API calls in elasticsearch-js follow the `(error, response)` callback parameter pattern, but the callback here was only expecting `(response)`.

Its possible this worked on older versions of the elasticsearch-js module, but not newer ones.

See https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-conventions.html#api-conventions-cb for more.

Fixes https://github.com/pelias/dbclient/issues/47