### PR TITLE
Update config and logger package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "elasticsearch": "^13.2.0",
     "joi": "^10.1.0",
     "openstreetmap-stream": "latest",
-    "pelias-config": "2.9.0",
-    "pelias-logger": "0.1.0",
+    "pelias-config": "2.12.0",
+    "pelias-logger": "0.2.0",
     "through2": "^2.0.1"
   },
   "pre-commit": [


### PR DESCRIPTION
PR for issue #56 .
Since there was an update of default elasticsearch module version it's required to update dependencies as well. Currently we have error `TypeError: Invalid apiVersion "2.3"` because of this.