### PR TITLE
fix: Reduce default number of max concurrent requests

### DIFF
--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -18,8 +18,8 @@ function BatchManager( opts ){
   // manager variable options
   this._opts = opts || {};
   if( !this._opts.flooding ){ this._opts.flooding = {}; }
-  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 50; } //50
-  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 8; } //8
+  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 10; } //50
+  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 2; } //8
 
   // internal variables
   this._current = new Batch( this._opts );


### PR DESCRIPTION
The BatchManager (roughly) manages the maximum number of bulk index requests that can be in processing by Elasticsearch simultaneously.

The default of 50 is good for very large clusters, but not small ones.

In order to make Pelias work better out of the box on smaller setups, the defaults should be changed. Worst case, this will make imports on larger Elasticsearch clusters slightly slower, but I doubt we'll even
notice. It might even make them faster.

Connects https://github.com/pelias/openaddresses/issues/328
Connects https://github.com/pelias/dbclient/issues/76