### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "elasticsearch": "^15.0.0",
     "joi": "^13.1.2",
-    "pelias-config": "3.0.2",
-    "pelias-logger": "0.4.2",
+    "pelias-config": "^3.0.2",
+    "pelias-logger": "^0.4.2",
     "through2": "^2.0.1"
   },
   "pre-commit": [


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366