### PR TITLE
Reduce default max in flight requests to 5

### DIFF
--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -8,7 +8,7 @@ function BatchManager( opts ){
   // manager variable options
   this._opts = opts || {};
   if( !this._opts.flooding ){ this._opts.flooding = {}; }
-  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 10; }
+  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 5; }
   if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 2; }
 
   // set up logger

--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -5,8 +5,6 @@ const pelias_logger = require( 'pelias-logger' );
 const Stats = require('./stats');
 
 function BatchManager( opts ){
-
-
   // manager variable options
   this._opts = opts || {};
   if( !this._opts.flooding ){ this._opts.flooding = {}; }

--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -1,14 +1,6 @@
 const Batch = require('./Batch');
 const transaction = require('./transaction');
 const pelias_logger = require( 'pelias-logger' );
-    // HealthCheck = require('./HealthCheck'),
-    // hc = new HealthCheck( client );
-
-// this may be required on nodejs <0.11
-// process.maxTickDepth = Infinity;
-
-// var debug = console.error.bind( console );
-// var debug = function(){};
 
 const Stats = require('./stats');
 
@@ -18,8 +10,8 @@ function BatchManager( opts ){
   // manager variable options
   this._opts = opts || {};
   if( !this._opts.flooding ){ this._opts.flooding = {}; }
-  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 10; } //50
-  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 2; } //8
+  if( !this._opts.flooding.pause ){ this._opts.flooding.pause = 10; }
+  if( !this._opts.flooding.resume ){ this._opts.flooding.resume = 2; }
 
   // set up logger
   const logger_name = this._opts.name ? `dbclient-${this._opts.name}` : 'dbclient';
@@ -32,10 +24,6 @@ function BatchManager( opts ){
   this._current = new Batch( this._opts );
   this._transient = 0;
   this._resumeFunc = undefined;
-
-  // stats.watch( 'healthcheck', function(){
-  //   return hc._status.threadpool.nodes;
-  // }.bind(this));
 
   this._stats.watch( 'paused', function(){
     return this.isPaused();


### PR DESCRIPTION
This package has historically been very aggressive regarding how many requests it will allow to be in flight to Elasticsearch.

We lowered the maximum number of in-flight requests to 10 recently (see #76), but I think this is still too high. Recently we have seen some Elasticsearch timeouts when running highly parallel imports.

My suspicion is that it's very unlikely a high number of in-flight bulk index requests is the best way to ensure high performance. For geocode.earth, we run planet builds on a 36 core machine, with a total of 6 importer processes running at once at the start (2 OA, OSM, polylines, geonames, WOF).

Since the bulk import endpoint already allows importing many records in parallel (500 by default in this package), 6 importers could lead to up to 60 bulk requests in flight at once, totaling 3000 records. My guess is even 2-3 bulk requests is enough to keep Elasticsearch busy, so the default config is doing nothing but filling up the Elasticsearch bulk threadpool and queue and bringing the cluster closer to tipping over the edge of too much load and having to drop requests.

Eventually I'd like to allow us to configure this option easily across all importers, but for now lets test this value.

Connects #76
Connects #83