### PR TITLE
feat(client): Remove use of singleton pattern

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,15 +1,6 @@
-
-var elasticsearch = require('elasticsearch'),
-    settings = require('pelias-config').generate();
-
-var singleton = null;
+const elasticsearch = require('elasticsearch');
+const settings = require('pelias-config').generate();
 
 module.exports = function(){
-
-  // Create new esclient with settings
-  if( !singleton ){
-    singleton = new elasticsearch.Client( settings.esclient || {} );
-  }
-
-  return singleton;
+  return new elasticsearch.Client( settings.esclient || {} );
 };


### PR DESCRIPTION
The singleton pattern has fallen out of favor lately, as it reduces the flexibility of a module, and sometimes makes it harder to unit test.

More details on the singleton pattern: https://stackoverflow.com/questions/12755539/why-is-singleton-considered-an-anti-pattern

This change removes dbclient's use of the singleton pattern, which should help folk who are using the module in ways we didn't anticipate.

Fixes https://github.com/pelias/dbclient/issues/77