### PR TITLE
Fix stats since we stops the use of type

### DIFF
--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -60,10 +60,11 @@ BatchManager.prototype._dispatch = function( batch, next ){
 
       batch._slots.forEach( function( task ){
         if( task.status < 299 ){
-          if( !types.hasOwnProperty( task.cmd.index._type ) ){
-            types[ task.cmd.index._type ] = 0;
+          const type = task.data.layer || task.cmd.index._type;
+          if( !types.hasOwnProperty( type ) ){
+            types[ type ] = 0;
           }
-          types[ task.cmd.index._type ]++;
+          types[ type ]++;
         } else {
           failures++;
         }


### PR DESCRIPTION
For the supports of ES6, we need to remove the type mapping. We removed the use of types in pelias/model#95 and now, the default value is `doc`.
This caused the suppression of the statistics when we do import. Instead of the layer, we only have `doc=x` instead of `address=x` for OA.

```
2019-09-18T21:27:28.360Z - info: [dbclient-openaddresses]  paused=false, transient=1, current_length=190, indexed=479421000, batch_ok=958842, batch_retries=0, failed_records=0, doc=479421000, persec=3000
```

This PR brings statistics back. It will use the layer value instead of the type. I added a fallback on `_type` just in case.

```
2019-09-27T09:50:02.852Z - info: [dbclient-openaddresses]  paused=false, transient=0, current_length=441, indexed=21500, batch_ok=43, batch_retries=0, failed_records=0, address=21500, persec=2150
```

connected to pelias/model#95
connected to pelias/pelias#719
