### PR TITLE
improved logging of batch indexing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "tape": "^4.4.0"
   },
   "dependencies": {
-    "elasticsearch": "^16.0.0",
     "@hapi/joi": "^15.0.0",
+    "elasticsearch": "^16.0.0",
+    "lodash": "^4.17.15",
     "pelias-config": "^4.0.0",
     "pelias-logger": "^1.2.1",
     "through2": "^3.0.0"

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const pelias_logger = require( 'pelias-logger' );
 
 var max_retries = 5;
@@ -62,6 +63,11 @@ function wrapper( client, parent_logger ){
 
           if( task.status > 201 ){
             logger.error( '[' + action.status + ']', action.error );
+
+            // additional debugging output of the error and corresponding request
+            var req = batch._slots.filter(s => _.get(s, 'cmd.index._id') === action._id);
+            logger.info(JSON.stringify(action, null, 2));
+            logger.info(JSON.stringify(req, null, 2));
           }
           // else {
           //   delete task.cmd; // reclaim memory


### PR DESCRIPTION
today I was debugging a batch indexing error and wasn't able to get enough information about the request in order to reproduce it.

this PR adds additional logging under the `info` log level which provides extended info about the error message and the original request.

I chose `info` because there is a log going on in `verbose` so I wanted something between that and `error` (and that's the only option).