### PR TITLE
remove `_type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,11 @@ const stream = streamify([1, 2, 3])
   .pipe(dbclient()); // put documents into elasticsearch
 
 stream.on('finish', () => {
-  // let's assume that documents with the same type but another timestamp (for example old copies)
-  // have to be deleted
   const client = new elasticsearch.Client(config.esclient);
   elasticDeleteQuery(client);
 
   const options = {
     index: config.schema.indexName,
-    type: 'venue',
     body: {
       query: {
         "bool": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@hapi/joi": "^16.0.0",
     "elasticsearch": "^16.0.0",
-    "pelias-config": "^5.2.0",
+    "pelias-config": "^6.0.0",
     "pelias-logger": "^1.2.1",
     "through2": "^3.0.0"
   },

--- a/src/BatchManager.js
+++ b/src/BatchManager.js
@@ -55,16 +55,11 @@ BatchManager.prototype._dispatch = function( batch, next ){
       this._stats.inc( 'indexed', batch._slots.length );
       this._stats.inc( 'batch_ok', 1 );
 
-      var types = {};
       var failures = 0;
 
-      batch._slots.forEach( function( task ){
+      batch._slots.forEach(( task ) => {
         if( task.status < 299 ){
-          const type = task.data.layer || task.cmd.index._type;
-          if( !types.hasOwnProperty( type ) ){
-            types[ type ] = 0;
-          }
-          types[ type ]++;
+          this._stats.inc( task.data.layer || 'default', 1 );
         } else {
           failures++;
         }
@@ -72,10 +67,6 @@ BatchManager.prototype._dispatch = function( batch, next ){
 
       this._stats.inc( 'batch_retries', batch.retries );
       this._stats.inc( 'failed_records', failures );
-
-      for( var type in types ){
-        this._stats.inc( type, types[type] );
-      }
     }
 
     // console.log( 'batch complete', err, batch._slots.length );

--- a/src/Task.js
+++ b/src/Task.js
@@ -5,7 +5,6 @@ function Task( record ){
   this.cmd = {
     index: {
       _index: record._index,
-      _type: record._type,
       _id: record._id
     }
   };

--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -15,8 +15,7 @@ const schema = Joi.object().keys({
     requestTimeout: Joi.number().integer().min(0)
   }).unknown(true),
   schema: Joi.object().keys({
-    indexName: Joi.string().required(),
-    typeName: Joi.string().required()
+    indexName: Joi.string().required()
   })
 }).unknown(true);
 

--- a/test/configValidation.js
+++ b/test/configValidation.js
@@ -11,8 +11,7 @@ module.exports.tests.validate = function(test, common) {
     var config = {
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -30,8 +29,7 @@ module.exports.tests.validate = function(test, common) {
       },
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -51,8 +49,7 @@ module.exports.tests.validate = function(test, common) {
         },
         esclient: {},
         schema: {
-          indexName: 'example_index',
-          typeName: 'example_type'
+          indexName: 'example_index'
         }
       };
 
@@ -74,8 +71,7 @@ module.exports.tests.validate = function(test, common) {
       },
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -94,8 +90,7 @@ module.exports.tests.validate = function(test, common) {
       },
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -115,8 +110,7 @@ module.exports.tests.validate = function(test, common) {
         },
         esclient: {},
         schema: {
-          indexName: 'example_index',
-          typeName: 'example_type'
+          indexName: 'example_index'
         }
       };
 
@@ -138,8 +132,7 @@ module.exports.tests.validate = function(test, common) {
       },
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -160,8 +153,7 @@ module.exports.tests.validate = function(test, common) {
         },
         esclient: value,
         schema: {
-          indexName: 'example_index',
-          typeName: 'example_type'
+          indexName: 'example_index'
         }
       };
 
@@ -186,8 +178,7 @@ module.exports.tests.validate = function(test, common) {
           requestTimeout: value
         },
         schema: {
-          indexName: 'example_index',
-          typeName: 'example_type'
+          indexName: 'example_index'
         }
       };
 
@@ -210,8 +201,7 @@ module.exports.tests.validate = function(test, common) {
         requestTimeout: 17.3
       },
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -233,8 +223,7 @@ module.exports.tests.validate = function(test, common) {
         requestTimeout: -1
       },
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -315,8 +304,7 @@ module.exports.tests.validate = function(test, common) {
       },
       esclient: {},
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -344,8 +332,7 @@ module.exports.tests.validate = function(test, common) {
         requestTimeout: 17
       },
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 
@@ -374,8 +361,7 @@ module.exports.tests.validate = function(test, common) {
         requestTimeout: 17
       },
       schema: {
-        indexName: 'example_index',
-        typeName: 'example_type'
+        indexName: 'example_index'
       }
     };
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -44,7 +44,6 @@ module.exports.tests.functional_example = function(test, common) {
     stream.pipe(assertStream);
     stream.write({
       _index: 'foo',
-      _type: 'foo',
       _id: 'foo',
       data: {}
     });


### PR DESCRIPTION
now that elasticsearch v6 support has been dropped we can remove any references to `_type` from this repo.

once this is merged we can update the importers, which currently fail with a message such as `Action/metadata line [1] contains an unknown parameter [_type]`

@michaelkirk would you mind doing a quick review for me please?

note: this should be versioned as a BREAKING CHANGE