### PR TITLE
Print specific error message

### DIFF
--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -32,6 +32,12 @@ module.exports = {
 
     // callback that throws an error if the index doesn't exist
     const existsCallback = (error, exists) => {
+      if (error) {
+        console.error(`ERROR: Failed to check if Elasticsearch index ${config.schema.indexName} exists.`);
+        console.error('For full instructions on setting up Pelias, see http://pelias.io/install.html');
+        throw error;
+      }
+
       if (!exists) {
         console.error(`ERROR: Elasticsearch index ${config.schema.indexName} does not exist`);
         console.error('You must use the pelias-schema tool (https://github.com/pelias/schema/) to create the index first');


### PR DESCRIPTION
#### Here's the reason for this change :rocket:

See https://github.com/pelias/docker/issues/217

Currently users are seeing "elasticsearch index pelias does not exist" even though it does exist.

This could happen if an error is encountered while making the request.

We should print a more useful error message in that case.

#### Here's what actually got changed :clap:

We now check to see if `error` is set before consulting `exists`.
If `error` is set, then `exists` can't be trusted.

#### Here's how others can test the changes :eyes:

Previously successful workflows should continue to succeed. Give them a try.

If you were experiencing a timeout with big planet builds, like in https://github.com/pelias/docker/issues/217, this should get you a better error message.

Here's output of my running a failed planet import after these changes:

```
Container pelias_schema  Started
Container pelias_elasticsearch  Running
waiting for elasticsearch service to come up
..........Elasticsearch up after waiting 11 second(s).
Container pelias_elasticsearch  Running

--------------
create index 
--------------

[put mapping]     pelias { acknowledged: true, shards_acknowledged: true, index: 'pelias' } 

Container pelias_elasticsearch  Running
ERROR: Failed to check if Elasticsearch index pelias exists.
For full instructions on setting up Pelias, see http://pelias.io/install.html

/code/pelias/whosonfirst/node_modules/pelias-dbclient/src/configValidation.js:38
      throw error;
     ^
StatusCodeError: Request Timeout after 120000ms
   at /code/pelias/whosonfirst/node_modules/elasticsearch/src/lib/transport.js:397:9
   at Timeout.<anonymous> (/code/pelias/whosonfirst/node_modules/elasticsearch/src/lib/transport.js:429:7)
   at listOnTimeout (node:internal/timers:559:17)
   at processTimers (node:internal/timers:502:7) {
      status: 408,
      displayName: 'RequestTimeout'
    }
```

This is much more helpful than: `ERROR: Elasticsearch index pelias does not exist` which was downright misleading.