### PR TITLE
Add file output option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
+const config = require('./src/config');
+
 if (process.env.NODE_ENV !== 'test') {
-  require('./src/configValidation').validate(require('pelias-config').generate());
+  const outputDirectory = config.get('outputDirectory');
+  if (!outputDirectory) {
+    require('./src/configValidation').validate(require('pelias-config').generate());
+  }
 }
 
-module.exports = require('./src/sink');
+module.exports = function(opts) {
+  const outputDirectory = config.get('outputDirectory');
+  if (outputDirectory) {
+    return require('./src/fileSink')(outputDirectory, opts);
+  }
+  return require('./src/sink')(opts);
+};

--- a/src/fileSink.js
+++ b/src/fileSink.js
@@ -1,0 +1,52 @@
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const through = require('through2');
+const pelias_logger = require('pelias-logger');
+const Stats = require('./stats');
+
+function fileSinkFactory(outputDirectory, opts) {
+  opts = opts || {};
+  const logger = pelias_logger.get(opts.name ? `dbclient-${opts.name}` : 'dbclient');
+  const stats = new Stats(logger);
+
+  const prefix = opts.name ? `pelias_${opts.name}` : 'pelias';
+  const filename = `${prefix}_${Date.now()}.ndjson`;
+  const filepath = path.join(outputDirectory, filename);
+  let writeStream = null;
+
+  function getWriteStream() {
+    if (!writeStream) {
+      writeStream = fs.createWriteStream(filepath, { flags: 'a' });
+      logger.info(`fileSink: writing documents to ${filepath}`);
+    }
+    return writeStream;
+  }
+
+  return through.obj(function(item, enc, next) {
+    const line = JSON.stringify(item.data) + '\n';
+    getWriteStream().write(line, function(err) {
+      if (err) {
+        logger.error('fileSink write error', err);
+        stats.inc('write_error', 1);
+      } else {
+        stats.inc('indexed', 1);
+        stats.inc(item.data.layer || 'default', 1);
+      }
+      next();
+    });
+  }, function(next) {
+    if (!writeStream) {
+      stats.end();
+      return next();
+    }
+    writeStream.end(function() {
+      stats.end();
+      next();
+    });
+  });
+}
+
+module.exports = fileSinkFactory;

--- a/test/fileSink.js
+++ b/test/fileSink.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const tape = require('tape');
+const fileSinkFactory = require('../src/fileSink');
+
+module.exports.tests = {};
+
+module.exports.tests.filename = function(test, common) {
+  test('fileSink: filename includes name from opts', function(t) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pelias-filesink-'));
+    const stream = fileSinkFactory(tmpDir, { name: 'openstreetmap' });
+    stream.write({ _index: 'pelias', _id: 'a', data: { name: 'foo', layer: 'venue' } });
+    stream.end(function() {
+      const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.ndjson'));
+      t.equal(files.length, 1, 'one file created');
+      t.ok(files[0].startsWith('pelias_openstreetmap_'), 'filename includes importer name');
+      fs.rmSync(tmpDir, { recursive: true });
+      t.end();
+    });
+  });
+
+  test('fileSink: filename uses pelias prefix without name', function(t) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pelias-filesink-'));
+    const stream = fileSinkFactory(tmpDir);
+    stream.write({ _index: 'pelias', _id: 'a', data: { name: 'foo', layer: 'venue' } });
+    stream.end(function() {
+      const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.ndjson'));
+      t.equal(files.length, 1, 'one file created');
+      t.ok(files[0].startsWith('pelias_'), 'filename uses default pelias prefix');
+      t.notOk(files[0].startsWith('pelias_undefined'), 'filename does not include undefined');
+      fs.rmSync(tmpDir, { recursive: true });
+      t.end();
+    });
+  });
+};
+
+module.exports.tests.writes_ndjson = function(test, common) {
+  test('fileSink: writes documents as ndjson', function(t) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pelias-filesink-'));
+    const stream = fileSinkFactory(tmpDir);
+
+    const docs = [
+      { _index: 'pelias', _id: 'a', data: { name: 'foo', layer: 'venue' } },
+      { _index: 'pelias', _id: 'b', data: { name: 'bar', layer: 'address' } },
+      { _index: 'pelias', _id: 'c', data: { name: 'baz', layer: 'venue' } }
+    ];
+
+    docs.forEach(doc => stream.write(doc));
+
+    stream.end(function() {
+      const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.ndjson'));
+      t.equal(files.length, 1, 'one ndjson file created');
+
+      const lines = fs.readFileSync(path.join(tmpDir, files[0]), 'utf8')
+        .trim().split('\n')
+        .map(l => JSON.parse(l));
+
+      t.equal(lines.length, 3, 'three lines written');
+      t.deepEqual(lines[0], docs[0].data, 'first doc data matches');
+      t.deepEqual(lines[1], docs[1].data, 'second doc data matches');
+      t.deepEqual(lines[2], docs[2].data, 'third doc data matches');
+
+      fs.rmSync(tmpDir, { recursive: true });
+      t.end();
+    });
+  });
+
+  test('fileSink: handles docs with mixed and missing layers', function(t) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pelias-filesink-'));
+    const stream = fileSinkFactory(tmpDir);
+
+    const docs = [
+      { _index: 'pelias', _id: 'a', data: { name: 'foo', layer: 'venue' } },
+      { _index: 'pelias', _id: 'b', data: { name: 'bar', layer: 'address' } },
+      { _index: 'pelias', _id: 'c', data: { name: 'baz', layer: 'venue' } },
+      { _index: 'pelias', _id: 'd', data: { name: 'qux' } }  // no layer → 'default'
+    ];
+
+    docs.forEach(doc => stream.write(doc));
+
+    stream.end(function() {
+      const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.ndjson'));
+      t.equal(files.length, 1, 'one ndjson file created');
+
+      const lines = fs.readFileSync(path.join(tmpDir, files[0]), 'utf8')
+        .trim().split('\n');
+      t.equal(lines.length, 4, 'all four docs written');
+
+      fs.rmSync(tmpDir, { recursive: true });
+      t.end();
+    });
+  });
+};
+
+module.exports.all = function(tape, common) {
+  function test(name, testFunction) {
+    return tape('fileSink: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -6,7 +6,8 @@ var tests = [
   require('./index'),
   require('./stream'),
   require('./configValidation'),
-  require('./Batch')
+  require('./Batch'),
+  require('./fileSink')
   // other tests go here
 ];
 


### PR DESCRIPTION
When configured, this allows writing LD-json to a file instead of batching and sending to Elasticsearch. The directory is configured by `dbclient.outputDirectory` in pelias.json, and setting that property enables file output. Each importer will write to a file with that importer's name and a timestamp.

This turns out to be extremely useful for debugging, performance testing, development, etc.